### PR TITLE
Removed setting bot max listeners

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -5,7 +5,7 @@ const config = require("./config.json");
 const bot = new Discord.Client({ disableEveryone: true });
 const axios = require("axios");
 bot.login(process.env.bot_token);
-bot.setMaxListeners(100);
+
 const enabled = true;
 
 const statcord = new Statcord.Client({


### PR DESCRIPTION
It's almost never a good idea to be setting maximum listeners to 100 or any extreme value. Listen to the errors that NodeJS gives you. Related to #1 